### PR TITLE
0.5 depwarn

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
 Colors
-Compat
+Compat 0.7.15
 FixedPointNumbers

--- a/src/VT100.jl
+++ b/src/VT100.jl
@@ -243,7 +243,7 @@ function dump(contents::IO, decorator::IO, em::Emulator, lines = nothing)
         end
         for cell in line
             c = cell.content
-            if c < 0xF0000
+            if c < '\Uf0000'
                 write(contents,c)
             else
                 write(contents,em.ExtendedContents[c])

--- a/src/VT100.jl
+++ b/src/VT100.jl
@@ -4,6 +4,7 @@ module VT100
 
 using Colors
 using FixedPointNumbers
+import Compat.String
 
 typealias RGB8 RGB{UFixed8}
 
@@ -114,7 +115,7 @@ abstract Emulator
 type ScreenEmulator <: Emulator
     ViewPortSize::Size
     firstline::Int
-    ExtendedContents::Vector{UTF8String}
+    ExtendedContents::Vector{String}
     lines::Vector{Line}
     cursor::Cursor
     cur_cell::Cell
@@ -122,7 +123,7 @@ type ScreenEmulator <: Emulator
     linedrawing::Bool
     function ScreenEmulator(width = 80, height = 24)
         this = new(Size(width, height),1,
-            Vector{UTF8String}(0),Vector{Line}(0),Cursor(1,1),Cell('\0'),
+            Vector{String}(0),Vector{Line}(0),Cursor(1,1),Cell('\0'),
             false, false)
         add_line!(this)
         this
@@ -224,7 +225,7 @@ const LineDrawing = [
 
 # Maintains an array of UTF8 sequences for combining characters, etc. Indexed
 # by C-U+F0000
-const ExtendedContents = UTF8String[]
+const ExtendedContents = String[]
 
 # Render the contents of this emulator into another terminal.
 function render(term::IO, em::Emulator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,8 @@ for test in [
         failed_tests += 1
         println(output)
         println(outbuf)
-        println(UTF8String(output))
-        println(UTF8String(outbuf))
+        println(Compat.UTF8String(output))
+        println(Compat.UTF8String(outbuf))
     end
 end
 exit(failed_tests)


### PR DESCRIPTION
The first commit is cherry-picked from the second commit in https://github.com/Keno/VT100.jl/pull/3.

I'm not sure what's the API of this package but given the tests passes on #3 (and locally on 0.4 and 0.5) and the only registered package that depends on this (TerminalUI.jl) is 0.5 only it should be safe to change the `UTF8String` to `String` in `src/`. The `test/` one needs to be `UTF8String` since `ByteString` cannot be used as constructor in this way.
