### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.in text eol=lf
-*.out text eol=lf


### PR DESCRIPTION
Ref. 724f8990304896157a3e1c9e9771af3ff0e72e45. For people who had it checked out on `master`, I'm not actually sure it's possible for the package manager to update this package without a `--force`; at least on Linux, just doing a `git pull` marked the package as dirty.

Fortunately, the last tag was just before the LF change, so hopefully most users will be running that.
