### PR TITLE
Refresh [compat] bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
   - linux
 julia:
   - 0.7
+  - 1.0
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "VT100"
 uuid = "7774df62-37c0-5c21-b34d-f6d7f98f54bc"
+version = "0.3.3"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -7,9 +8,9 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-ColorTypes = "≥ 0.3.4"
-FixedPointNumbers = "≥ 0.3.0"
-julia = "≥ 0.7.0"
+ColorTypes = "0.7, 0.8, 0.9"
+FixedPointNumbers = "0.5, 0.6, 0.7"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
New releases require upper bounds for automatic merging. Moreover, version caps were placed on the registry that were more restrictive this package's Project.toml: https://github.com/JuliaRegistries/General/blob/master/V/VT100/Compat.toml. Consequently this cannot be used in conjunction with modern versions of FixedPointNumbers.

The easiest way to fix the problem is to do a new release. Once this merges, can you register it?